### PR TITLE
fix: avoid panic during invalid UTF-8 Path serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "grep-cli"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3592784f7791f5f0bfc2e4b5595dc2d4e34a79099d7228d121b954bae73db182"
+dependencies = [
+ "atty",
+ "bstr",
+ "globset",
+ "lazy_static",
+ "log",
+ "regex",
+ "same-file",
+ "termcolor",
+ "winapi-util",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1053,7 @@ dependencies = [
  "dunce",
  "env_logger",
  "globset",
+ "grep-cli",
  "highway",
  "human-panic",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ build-bin = [
 crossbeam-channel = "0.5.0"
 dunce = "1.0.1"
 globset = "0.4.6"
+grep-cli = "0.1.5"
 ignore = "0.4.16"
 log = "0.4.11"
 num_cpus = "1.13.0"

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -59,7 +59,7 @@ where
         .collect()
 }
 
-pub(crate) fn dedupe<H>(counter: TreeBag<u64, PathBuf>) -> TreeBag<u64, PathBuf>
+pub(crate) fn dedupe<H>(counter: TreeBag<u64, PathBuf>) -> TreeBag<u64, crate::path::Path>
 where
     H: Hasher + Default,
 {
@@ -70,13 +70,13 @@ where
         .for_each_with(sender, |sender, (old_hash, bucket)| {
             if bucket.len() == 1 {
                 let file = bucket.into_iter().next().unwrap();
-                sender.send((old_hash, file)).unwrap();
+                sender.send((old_hash, file.into())).unwrap();
             } else {
                 bucket
                     .into_par_iter()
                     .for_each_with(sender.clone(), |sender, file| {
                         let hash = rehash::<H>(&file).unwrap_or(old_hash);
-                        sender.send((hash, file)).unwrap();
+                        sender.send((hash, file.into())).unwrap();
                     });
             }
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,13 @@
 
 mod bag;
 mod fs;
+pub mod path;
 
 pub use bag::{Factor, Fdupes, Machine, Replicates, TreeBag};
 pub use globset;
 pub use regex;
 use std::hash::Hasher;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Search configuration
 ///
@@ -68,7 +69,7 @@ where
     P: AsRef<Path>,
 {
     /// This will attemps a complete scan according to its configuration.
-    pub fn scan<H>(self) -> TreeBag<u64, PathBuf>
+    pub fn scan<H>(self) -> TreeBag<u64, path::Path>
     where
         H: Hasher + Default,
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ enum ReplicationFactor {
 /// mimic serde_json interface
 fn csv_to_writer<W: std::io::Write>(
     writer: W,
-    replicates: &yadf::Replicates<u64, PathBuf>,
+    replicates: &yadf::Replicates<u64, yadf::path::Path>,
 ) -> csv::Result<()> {
     let mut writer = csv::WriterBuilder::new()
         .flexible(true)
@@ -149,7 +149,7 @@ fn csv_to_writer<W: std::io::Write>(
 /// mimic serde_json interface
 fn ldjson_to_writer<W: std::io::Write>(
     mut writer: W,
-    replicates: &yadf::Replicates<u64, PathBuf>,
+    replicates: &yadf::Replicates<u64, yadf::path::Path>,
 ) -> serde_json::Result<()> {
     for files in replicates.iter() {
         serde_json::to_writer(&mut writer, &files)?;
@@ -163,7 +163,7 @@ mod tests {
     use super::*;
     use once_cell::sync::Lazy;
 
-    static BAG: Lazy<yadf::TreeBag<u64, PathBuf>> = Lazy::new(|| {
+    static BAG: Lazy<yadf::TreeBag<u64, yadf::path::Path>> = Lazy::new(|| {
         vec![
             (77, "hello".into()),
             (77, "world".into()),

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,56 @@
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Path(std::path::PathBuf);
+
+use serde::{Serialize, Serializer};
+
+impl Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self.0.to_str() {
+            Some(path) => serializer.serialize_str(path),
+            None => {
+                log::warn!("path contains invalid UTF-8 characters : {:?}", self.0);
+                serializer.serialize_str(&grep_cli::escape_os(self.0.as_ref()))
+            }
+        }
+    }
+}
+
+impl<T> From<T> for Path
+where
+    T: Into<std::path::PathBuf>,
+{
+    fn from(path: T) -> Self {
+        Self(path.into())
+    }
+}
+
+impl AsRef<std::path::Path> for Path {
+    fn as_ref(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn shouldnt_panic_on_invalid_utf8_path() {
+        use super::*;
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        use std::path::PathBuf;
+        // asserts its invalidity
+        let invalid_utf8: &[u8] = b"\xe7\xe7";
+        assert!(String::from_utf8(invalid_utf8.to_vec()).is_err());
+        // without wrapper it errors
+        let path = PathBuf::from(OsString::from_vec(invalid_utf8.to_vec()));
+        assert!(serde_json::to_string(&path).is_err());
+        // with wrapper it's ok
+        let path = Path(PathBuf::from(OsString::from_vec(invalid_utf8.to_vec())));
+        assert!(serde_json::to_string(&path).is_ok());
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,11 +1,25 @@
-mod test_dir;
-
-use test_dir::TestDir;
-
 /// quick-n-dirty any result type alias
-type AnyResult<T = (), E = Box<dyn std::error::Error>> = Result<T, E>;
+pub type AnyResult<T = (), E = Box<dyn std::error::Error>> = Result<T, E>;
 
-const MAX_LEN: usize = 256 * 1024;
+pub const MAX_LEN: usize = 256 * 1024;
+
+pub fn random_collection<T, I>(size: usize) -> I
+where
+    rand::distributions::Standard: rand::distributions::Distribution<T>,
+    I: std::iter::FromIterator<T>,
+{
+    use rand::Rng;
+    let mut rng = rand::thread_rng();
+    std::iter::repeat_with(|| rng.gen()).take(size).collect()
+}
+
+/// test shortcut
+pub fn find_dupes<P: AsRef<std::path::Path>>(path: &P) -> yadf::TreeBag<u64, yadf::path::Path> {
+    yadf::Yadf::builder()
+        .paths(&[path])
+        .build()
+        .scan::<seahash::SeaHasher>()
+}
 
 /// Test to be sure the sorting by hash only groups together files
 /// with the same contents.
@@ -24,283 +38,5 @@ fn sanity_check() {
             let contents = std::fs::read(&file).unwrap();
             assert_eq!(reference, contents, "comparing {:?} and {:?}", first, file);
         }
-    }
-}
-
-macro_rules! scope_name_iter {
-    () => {{
-        fn fxxfxxf() {}
-        fn type_name_of<T>(_: T) -> &'static str {
-            std::any::type_name::<T>()
-        }
-        type_name_of(fxxfxxf)
-            .split("::")
-            .take_while(|&segment| segment != "fxxfxxf")
-    }};
-}
-
-#[test]
-fn function_name() {
-    let fname = scope_name_iter!().collect::<Vec<_>>().join("::");
-    assert_eq!(fname, "common::function_name");
-}
-
-macro_rules! test_dir {
-    () => {{
-        ["target", "tests"]
-            .iter()
-            .copied()
-            .chain(scope_name_iter!())
-            .collect::<std::path::PathBuf>()
-    }};
-}
-
-#[test]
-fn dir_macro() {
-    let path = test_dir!();
-    #[cfg(windows)]
-    assert_eq!(path.to_str(), Some("target\\tests\\common\\dir_macro"));
-    #[cfg(not(windows))]
-    assert_eq!(path.to_str(), Some("target/tests/common/dir_macro"));
-}
-
-fn random_collection<T, I>(size: usize) -> I
-where
-    rand::distributions::Standard: rand::distributions::Distribution<T>,
-    I: std::iter::FromIterator<T>,
-{
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
-    std::iter::repeat_with(|| rng.gen()).take(size).collect()
-}
-
-/// test shortcut
-fn find_dupes<P: AsRef<std::path::Path>>(path: &P) -> yadf::TreeBag<u64, std::path::PathBuf> {
-    yadf::Yadf::builder()
-        .paths(&[path])
-        .build()
-        .scan::<seahash::SeaHasher>()
-}
-
-#[test]
-fn identical_small_files() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    println!("{:?}", root.as_ref());
-    root.write_file("file1", b"aaa")?;
-    root.write_file("file2", b"aaa")?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 1);
-    assert_eq!(counter.as_tree().len(), 1);
-    Ok(())
-}
-
-#[test]
-fn identical_larger_files() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    let buffer: Vec<_> = random_collection(MAX_LEN * 3);
-    root.write_file("file1", &buffer)?;
-    root.write_file("file2", &buffer)?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 1);
-    assert_eq!(counter.as_tree().len(), 1);
-    Ok(())
-}
-
-#[test]
-fn files_differing_by_size() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    root.write_file("file1", b"aaaa")?;
-    root.write_file("file2", b"aaa")?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 0);
-    assert_eq!(counter.as_tree().len(), 2);
-    Ok(())
-}
-
-#[test]
-fn files_differing_by_prefix() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    root.write_file("file1", b"aaa")?;
-    root.write_file("file2", b"bbb")?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 0);
-    assert_eq!(counter.as_tree().len(), 2);
-    Ok(())
-}
-
-#[test]
-fn files_differing_by_suffix() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    let mut buffer1 = Vec::with_capacity(MAX_LEN * 3 + 4);
-    buffer1.extend_from_slice(&random_collection::<_, Vec<_>>(MAX_LEN * 3));
-    let mut buffer2 = buffer1.clone();
-    buffer1.extend_from_slice(b"suf1");
-    buffer2.extend_from_slice(b"suf2");
-    root.write_file("file1", &buffer1)?;
-    root.write_file("file2", &buffer2)?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 0);
-    assert_eq!(counter.as_tree().len(), 2);
-    Ok(())
-}
-
-#[test]
-fn files_differing_by_middle() -> AnyResult {
-    let root = TestDir::new(test_dir!())?;
-    let mut buffer1 = Vec::with_capacity(MAX_LEN * 2 + 4);
-    buffer1.extend_from_slice(&random_collection::<_, Vec<_>>(MAX_LEN));
-    let mut buffer2 = buffer1.clone();
-    buffer1.extend_from_slice(b"mid1");
-    buffer2.extend_from_slice(b"mid2");
-    let suffix = random_collection::<_, Vec<_>>(MAX_LEN);
-    buffer1.extend_from_slice(&suffix);
-    buffer2.extend_from_slice(&suffix);
-    root.write_file("file1", &buffer1)?;
-    root.write_file("file2", &buffer2)?;
-    let counter = find_dupes(&root);
-    assert_eq!(counter.duplicates().iter().count(), 0);
-    assert_eq!(counter.as_tree().len(), 2);
-    Ok(())
-}
-
-mod integration {
-    use super::test_dir::TestDir;
-    use super::{random_collection, AnyResult, MAX_LEN};
-    use predicates::{boolean::PredicateBooleanExt, str as predstr};
-
-    #[test]
-    fn trace_output() -> AnyResult {
-        let root = TestDir::new(test_dir!())?;
-        println!("{:?}", root.as_ref());
-        let bytes: Vec<_> = random_collection(MAX_LEN);
-        let file1 = root.write_file("file1", &bytes)?;
-        let file2 = root.write_file("file2", &bytes)?;
-        root.write_file("file3", &bytes[..4096])?;
-        root.write_file("file4", &bytes[..2048])?;
-        let expected = serde_json::to_string(&[[file1.to_string_lossy(), file2.to_string_lossy()]])
-            .unwrap()
-            + "\n";
-        assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
-            .arg("-vvvv") // test stderr contains enough debug output
-            .args(&["--format", "json"])
-            .args(&["--algorithm", "seahash"])
-            .arg(root.as_ref())
-            .assert()
-            .success()
-            .stderr(
-                predstr::contains("Args {")
-                    .and(predstr::contains("Yadf {"))
-                    .and(predstr::contains("format: Json"))
-                    .and(predstr::contains("algorithm: SeaHash"))
-                    .and(predstr::contains("verbose: 4"))
-                    .and(predstr::contains(
-                        "found 3 possible duplicates after initial scan",
-                    ))
-                    .and(predstr::contains(
-                        "found 2 duplicates in 1 groups after checksumming",
-                    ))
-                    .and(predstr::contains("file1"))
-                    .and(predstr::contains("file2"))
-                    .and(predstr::contains("file3"))
-                    .and(predstr::contains("file4")),
-            )
-            .stdout(predstr::similar(expected).distance(2));
-        Ok(())
-    }
-
-    #[test]
-    fn regex() -> AnyResult {
-        let root = TestDir::new(test_dir!())?;
-        let bytes: Vec<_> = random_collection(4096);
-        let particular_1_name = root.write_file("particular_1_name", &bytes)?;
-        let particular_2_name = root.write_file("particular_2_name", &bytes)?;
-        root.write_file("not_particular_2_name", &bytes)?;
-        root.write_file("completely_different", &bytes)?;
-        let expected = [
-            particular_1_name.to_string_lossy(),
-            particular_2_name.to_string_lossy(),
-        ]
-        .join("\n")
-            + "\n";
-        assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
-            .args(&["--regex", "^particular_\\d_name$"])
-            .arg(root.as_ref())
-            .assert()
-            .success()
-            .stderr(predstr::is_empty())
-            .stdout(predstr::similar(expected).distance(2));
-        Ok(())
-    }
-
-    #[test]
-    fn glob_pattern() -> AnyResult {
-        let root = TestDir::new(test_dir!())?;
-        let bytes: Vec<_> = random_collection(4096);
-        let particular_1_name = root.write_file("particular_1_name", &bytes)?;
-        let particular_2_name = root.write_file("particular_2_name", &bytes)?;
-        root.write_file("not_particular_2_name", &bytes)?;
-        root.write_file("completely_different", &bytes)?;
-        let expected = [
-            particular_1_name.to_string_lossy(),
-            particular_2_name.to_string_lossy(),
-        ]
-        .join("\n")
-            + "\n";
-        assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
-            .args(&["--pattern", "particular*name"])
-            .arg(root.as_ref())
-            .assert()
-            .success()
-            .stderr(predstr::is_empty())
-            .stdout(predstr::similar(expected).distance(2));
-        Ok(())
-    }
-
-    #[test]
-    fn min_file_size() -> AnyResult {
-        let root = TestDir::new(test_dir!())?;
-        let bytes: Vec<_> = random_collection(4096);
-        let particular_1_name = root.write_file("particular_1_name", &bytes)?;
-        let particular_2_name = root.write_file("particular_2_name", &bytes)?;
-        root.write_file("not_particular_2_name", &bytes[..2048])?;
-        root.write_file("completely_different", &bytes[..2048])?;
-        let expected = [
-            particular_1_name.to_string_lossy(),
-            particular_2_name.to_string_lossy(),
-        ]
-        .join("\n")
-            + "\n";
-        assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
-            .args(&["--min", "4K"])
-            .arg(root.as_ref())
-            .assert()
-            .success()
-            .stderr(predstr::is_empty())
-            .stdout(predstr::similar(expected).distance(2));
-        Ok(())
-    }
-
-    #[test]
-    fn max_file_size() -> AnyResult {
-        let root = TestDir::new(test_dir!())?;
-        let bytes: Vec<_> = random_collection(4096);
-        let particular_1_name = root.write_file("particular_1_name", &bytes[..1024])?;
-        let particular_2_name = root.write_file("particular_2_name", &bytes[..1024])?;
-        root.write_file("not_particular_2_name", &bytes)?;
-        root.write_file("completely_different", &bytes)?;
-        let expected = [
-            particular_1_name.to_string_lossy(),
-            particular_2_name.to_string_lossy(),
-        ]
-        .join("\n")
-            + "\n";
-        assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
-            .args(&["--max", "2K"])
-            .arg(root.as_ref())
-            .assert()
-            .success()
-            .stderr(predstr::is_empty())
-            .stdout(predstr::similar(expected).distance(2));
-        Ok(())
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,196 @@
+mod common;
+mod test_dir;
+
+use common::{random_collection, AnyResult, MAX_LEN};
+use predicates::{boolean::PredicateBooleanExt, str as predstr};
+use test_dir::TestDir;
+
+macro_rules! scope_name_iter {
+    () => {{
+        fn fxxfxxf() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        type_name_of(fxxfxxf)
+            .split("::")
+            .take_while(|&segment| segment != "fxxfxxf")
+    }};
+}
+
+#[test]
+fn function_name() {
+    let fname = scope_name_iter!().collect::<Vec<_>>().join("::");
+    assert_eq!(fname, "integration::function_name");
+}
+
+macro_rules! test_dir {
+    () => {{
+        ["target", "tests"]
+            .iter()
+            .copied()
+            .chain(scope_name_iter!())
+            .collect::<std::path::PathBuf>()
+    }};
+}
+
+#[test]
+fn dir_macro() {
+    let path = test_dir!();
+    #[cfg(windows)]
+    assert_eq!(path.to_str(), Some("target\\tests\\integration\\dir_macro"));
+    #[cfg(not(windows))]
+    assert_eq!(path.to_str(), Some("target/tests/integration/dir_macro"));
+}
+
+#[test]
+fn trace_output() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    println!("{:?}", root.as_ref());
+    let bytes: Vec<_> = random_collection(MAX_LEN);
+    let file1 = root.write_file("file1", &bytes)?;
+    let file2 = root.write_file("file2", &bytes)?;
+    root.write_file("file3", &bytes[..4096])?;
+    root.write_file("file4", &bytes[..2048])?;
+    let expected = serde_json::to_string(&[[file1.to_string_lossy(), file2.to_string_lossy()]])
+        .unwrap()
+        + "\n";
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .arg("-vvvv") // test stderr contains enough debug output
+        .args(&["--format", "json"])
+        .args(&["--algorithm", "seahash"])
+        .arg(root.as_ref())
+        .assert()
+        .success()
+        .stderr(
+            predstr::contains("Args {")
+                .and(predstr::contains("Yadf {"))
+                .and(predstr::contains("format: Json"))
+                .and(predstr::contains("algorithm: SeaHash"))
+                .and(predstr::contains("verbose: 4"))
+                .and(predstr::contains(
+                    "found 3 possible duplicates after initial scan",
+                ))
+                .and(predstr::contains(
+                    "found 2 duplicates in 1 groups after checksumming",
+                ))
+                .and(predstr::contains("file1"))
+                .and(predstr::contains("file2"))
+                .and(predstr::contains("file3"))
+                .and(predstr::contains("file4")),
+        )
+        .stdout(predstr::similar(expected).distance(2));
+    Ok(())
+}
+
+#[test]
+fn regex() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let bytes: Vec<_> = random_collection(4096);
+    let particular_1_name = root.write_file("particular_1_name", &bytes)?;
+    let particular_2_name = root.write_file("particular_2_name", &bytes)?;
+    root.write_file("not_particular_2_name", &bytes)?;
+    root.write_file("completely_different", &bytes)?;
+    let expected = [
+        particular_1_name.to_string_lossy(),
+        particular_2_name.to_string_lossy(),
+    ]
+    .join("\n")
+        + "\n";
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .args(&["--regex", "^particular_\\d_name$"])
+        .arg(root.as_ref())
+        .assert()
+        .success()
+        .stderr(predstr::is_empty())
+        .stdout(predstr::similar(expected).distance(2));
+    Ok(())
+}
+
+#[test]
+fn glob_pattern() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let bytes: Vec<_> = random_collection(4096);
+    let particular_1_name = root.write_file("particular_1_name", &bytes)?;
+    let particular_2_name = root.write_file("particular_2_name", &bytes)?;
+    root.write_file("not_particular_2_name", &bytes)?;
+    root.write_file("completely_different", &bytes)?;
+    let expected = [
+        particular_1_name.to_string_lossy(),
+        particular_2_name.to_string_lossy(),
+    ]
+    .join("\n")
+        + "\n";
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .args(&["--pattern", "particular*name"])
+        .arg(root.as_ref())
+        .assert()
+        .success()
+        .stderr(predstr::is_empty())
+        .stdout(predstr::similar(expected).distance(2));
+    Ok(())
+}
+
+#[test]
+fn min_file_size() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let bytes: Vec<_> = random_collection(4096);
+    let particular_1_name = root.write_file("particular_1_name", &bytes)?;
+    let particular_2_name = root.write_file("particular_2_name", &bytes)?;
+    root.write_file("not_particular_2_name", &bytes[..2048])?;
+    root.write_file("completely_different", &bytes[..2048])?;
+    let expected = [
+        particular_1_name.to_string_lossy(),
+        particular_2_name.to_string_lossy(),
+    ]
+    .join("\n")
+        + "\n";
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .args(&["--min", "4K"])
+        .arg(root.as_ref())
+        .assert()
+        .success()
+        .stderr(predstr::is_empty())
+        .stdout(predstr::similar(expected).distance(2));
+    Ok(())
+}
+
+#[test]
+fn max_file_size() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let bytes: Vec<_> = random_collection(4096);
+    let particular_1_name = root.write_file("particular_1_name", &bytes[..1024])?;
+    let particular_2_name = root.write_file("particular_2_name", &bytes[..1024])?;
+    root.write_file("not_particular_2_name", &bytes)?;
+    root.write_file("completely_different", &bytes)?;
+    let expected = [
+        particular_1_name.to_string_lossy(),
+        particular_2_name.to_string_lossy(),
+    ]
+    .join("\n")
+        + "\n";
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .args(&["--max", "2K"])
+        .arg(root.as_ref())
+        .assert()
+        .success()
+        .stderr(predstr::is_empty())
+        .stdout(predstr::similar(expected).distance(2));
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn non_utf8_paths() -> AnyResult {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use std::path::PathBuf;
+    let root = TestDir::new(test_dir!())?;
+    let filename = PathBuf::from(OsString::from_vec(b"\xe7\xe7".to_vec()));
+    root.write_file(&filename, b"")?;
+    assert_cmd::Command::cargo_bin(assert_cmd::crate_name!())?
+        .arg(root.as_ref())
+        .args(&["-f", "json"])
+        .assert()
+        .success();
+    Ok(())
+}

--- a/tests/particular_cases.rs
+++ b/tests/particular_cases.rs
@@ -1,0 +1,108 @@
+mod common;
+mod test_dir;
+
+use common::{find_dupes, random_collection, AnyResult, MAX_LEN};
+use test_dir::TestDir;
+
+macro_rules! scope_name_iter {
+    () => {{
+        fn fxxfxxf() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        type_name_of(fxxfxxf)
+            .split("::")
+            .take_while(|&segment| segment != "fxxfxxf")
+    }};
+}
+
+macro_rules! test_dir {
+    () => {{
+        ["target", "tests"]
+            .iter()
+            .copied()
+            .chain(scope_name_iter!())
+            .collect::<std::path::PathBuf>()
+    }};
+}
+
+#[test]
+fn identical_small_files() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    println!("{:?}", root.as_ref());
+    root.write_file("file1", b"aaa")?;
+    root.write_file("file2", b"aaa")?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 1);
+    assert_eq!(counter.as_tree().len(), 1);
+    Ok(())
+}
+
+#[test]
+fn identical_larger_files() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let buffer: Vec<_> = random_collection(MAX_LEN * 3);
+    root.write_file("file1", &buffer)?;
+    root.write_file("file2", &buffer)?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 1);
+    assert_eq!(counter.as_tree().len(), 1);
+    Ok(())
+}
+
+#[test]
+fn files_differing_by_size() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    root.write_file("file1", b"aaaa")?;
+    root.write_file("file2", b"aaa")?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 0);
+    assert_eq!(counter.as_tree().len(), 2);
+    Ok(())
+}
+
+#[test]
+fn files_differing_by_prefix() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    root.write_file("file1", b"aaa")?;
+    root.write_file("file2", b"bbb")?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 0);
+    assert_eq!(counter.as_tree().len(), 2);
+    Ok(())
+}
+
+#[test]
+fn files_differing_by_suffix() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let mut buffer1 = Vec::with_capacity(MAX_LEN * 3 + 4);
+    buffer1.extend_from_slice(&random_collection::<_, Vec<_>>(MAX_LEN * 3));
+    let mut buffer2 = buffer1.clone();
+    buffer1.extend_from_slice(b"suf1");
+    buffer2.extend_from_slice(b"suf2");
+    root.write_file("file1", &buffer1)?;
+    root.write_file("file2", &buffer2)?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 0);
+    assert_eq!(counter.as_tree().len(), 2);
+    Ok(())
+}
+
+#[test]
+fn files_differing_by_middle() -> AnyResult {
+    let root = TestDir::new(test_dir!())?;
+    let mut buffer1 = Vec::with_capacity(MAX_LEN * 2 + 4);
+    buffer1.extend_from_slice(&random_collection::<_, Vec<_>>(MAX_LEN));
+    let mut buffer2 = buffer1.clone();
+    buffer1.extend_from_slice(b"mid1");
+    buffer2.extend_from_slice(b"mid2");
+    let suffix = random_collection::<_, Vec<_>>(MAX_LEN);
+    buffer1.extend_from_slice(&suffix);
+    buffer2.extend_from_slice(&suffix);
+    root.write_file("file1", &buffer1)?;
+    root.write_file("file2", &buffer2)?;
+    let counter = find_dupes(&root);
+    assert_eq!(counter.duplicates().iter().count(), 0);
+    assert_eq!(counter.as_tree().len(), 2);
+    Ok(())
+}


### PR DESCRIPTION
`serde_json` has chosen to serialize `std::path::Path` as a `str`, if that path doesn't pass the utf-8 check, that causes the whole serialization to error. I've chosen to panic if an error happens during serialization. This PR aims to avoid that panic by checking myself if the path is valid utf-8 and, if it isn't, escape it.

Fix #3 